### PR TITLE
Builds on go 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Intensifier
+
+Intensifier intensifies.
+
+## Usage
+
+```
+./intensifier -h
+
+  -expire duration
+        time to expire images after (default 336h0m0s)
+  -font string
+        font to use (default "/usr/share/fonts/truetype/msttcorefonts/impact.ttf")
+  -port int
+        port to listen on (default 8080)
+```
+
+## Results
+
+![](https://i.imgur.com/mw5XZb5.gif)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/hdonnay/intensifier
+
+go 1.12
+
+require (
+	github.com/golang/freetype v0.0.0-20150812043419-5193f9f147f3
+	golang.org/x/image v0.0.0-20190516052701-61b8692d9a5c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/golang/freetype v0.0.0-20150812043419-5193f9f147f3 h1:rU9E/d4HGSsXuNeE57w/HelnCRlyjAyKr+yf+0HyX34=
+github.com/golang/freetype v0.0.0-20150812043419-5193f9f147f3/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+golang.org/x/image v0.0.0-20190516052701-61b8692d9a5c h1:VgWXv7ME0Tq2L5CBzVvhTMrfcKfvGs7ifTV9PBYTP3I=
+golang.org/x/image v0.0.0-20190516052701-61b8692d9a5c/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -20,9 +20,9 @@ import (
 	"strconv"
 	"time"
 
-	"code.google.com/p/freetype-go/freetype"
-	"code.google.com/p/freetype-go/freetype/raster"
-	"code.google.com/p/freetype-go/freetype/truetype"
+	"github.com/golang/freetype"
+	"github.com/golang/freetype/raster"
+	"github.com/golang/freetype/truetype"
 )
 
 var (
@@ -106,7 +106,7 @@ func (m *Memer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	g := gif.GIF{
 		Image:     make([]*image.Paletted, m.Frames),
 		Delay:     make([]int, m.Frames),
-		LoopCount: -1,
+		LoopCount: 0,
 	}
 	if err := r.ParseMultipartForm(1 << 13); err != nil {
 		log.Println(err)


### PR DESCRIPTION
I needed this in my life @hdonnay.

At some point `code.google` gave up the ghost & now they want `LoopCount` at zero to loop forever ([ref](https://golang.org/pkg/image/gif/#GIF)).